### PR TITLE
Fix rename/delete conversations, add import conversation

### DIFF
--- a/export-codebase.ipynb
+++ b/export-codebase.ipynb
@@ -2,14 +2,14 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Tokens: 218471\n"
+      "Tokens: 160671\n"
      ]
     }
    ],
@@ -47,6 +47,8 @@
     "            if \"components/ui\" in root:\n",
     "                continue\n",
     "            if \"components/home\" in root:\n",
+    "                continue\n",
+    "            if \"docs-agixt\" in root:\n",
     "                continue\n",
     "            if file.endswith(\".py\"):\n",
     "                python_files.append(os.path.join(root, file))\n",


### PR DESCRIPTION
- Fixes #39 
- Fixes #7
- Fixes the state management on delete to update the UI when a conversation is deleted.
- Removes the automatic rename that the front end does, moved this functionality to the back end. 

