### PR TITLE
Load documentation side menu with other items

### DIFF
--- a/components/layout/NavMain.tsx
+++ b/components/layout/NavMain.tsx
@@ -251,11 +251,17 @@ export function NavMain() {
   const { toggleSidebar, open } = useSidebar('left');
 
   const itemsWithActiveState = useMemo(() => {
+    const isAuthLoading = !company && !companyError;
+
+    if (isAuthLoading) {
+      return [];
+    }
     return items
       .filter((item) => {
         const hasJwt = !!getCookie('jwt');
         const hasCompany = !!company && !companyError;
         const meetsRoleThreshold = !item.roleThreshold || (hasCompany && company.roleId <= item.roleThreshold);
+
         if (!hasJwt || !hasCompany) {
           return item.title === 'Documentation';
         }


### PR DESCRIPTION
The documentation link loaded faster in the menu than the other items which sometimes made it seem like the login wasn't fully successful with the delay. I have moved the documentation link to appear at the same time as the other menu items.