### PR TITLE
Move and fix overrides

### DIFF
--- a/components/agent/abilities.tsx
+++ b/components/agent/abilities.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import axios from 'axios';
-import { getCookie } from 'cookies-next';
+import { getCookie, setCookie } from 'cookies-next';
 import { useSearchParams } from 'next/navigation';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useAgent } from '@/components/idiot/interactive/hooks/useAgent';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -12,6 +12,32 @@ import { Switch } from '@/components/ui/switch';
 import MarkdownBlock from '@/components/conversation/Message/MarkdownBlock';
 import { useCompany } from '@/components/idiot/useUser';
 import { Input } from '@/components/ui/input';
+import { Wrench } from 'lucide-react';
+
+// Define override extensions (moved from Extension.jsx)
+const OVERRIDE_EXTENSIONS = {
+  'text-to-speech': {
+    name: 'tts',
+    label: 'Text to Speech',
+    description: 'Convert text responses to spoken audio output with each response.',
+  },
+  'web-search': {
+    name: 'websearch',
+    label: 'Web Search',
+    description: 'Search and reference current web content with each request.',
+  },
+  'image-generation': {
+    name: 'create-image',
+    label: 'Image Generation',
+    description: 'Enable the assistant to generate images based on user prompts.',
+  },
+  analysis: {
+    name: 'analyze-user-input',
+    label: 'Data Analysis',
+    description:
+      'Analyze uploaded files, documents, available data, and user input to solve math problems, create graphs, and create and run code to analyze data.',
+  },
+};
 
 // Types remain the same
 type Command = {
@@ -36,6 +62,23 @@ export function Abilities() {
   const agent_name = getCookie('agixt-agent') || process.env.NEXT_PUBLIC_AGIXT_AGENT;
   const { data: activeCompany, mutate: mutateCompany } = useCompany();
   const searchParams = useSearchParams();
+
+  // State for override extensions
+  const [overrideStates, setOverrideStates] = useState<Record<string, boolean>>({});
+
+  // Initialize override extension states
+  useEffect(() => {
+    const states = Object.entries(OVERRIDE_EXTENSIONS).reduce(
+      (acc, [key, value]) => {
+        acc[key] = getCookie(`agixt-${value.name}`) === 'true';
+        return acc;
+      },
+      {} as Record<string, boolean>,
+    );
+
+    setOverrideStates(states);
+  }, []);
+
   // Filter extensions for the enabled commands view
   const extensions = searchParams.get('mode') === 'company' ? activeCompany?.extensions || [] : agentData?.extensions || [];
   const extensionsWithCommands = extensions.filter((ext) => ext.commands?.length > 0);
@@ -46,7 +89,6 @@ export function Abilities() {
         searchParams.get('mode') === 'company'
           ? `${process.env.NEXT_PUBLIC_AGIXT_SERVER}/v1/companies/${activeCompany?.id}/command`
           : `${process.env.NEXT_PUBLIC_AGIXT_SERVER}/api/agent/${agent_name}/command`,
-
         {
           command_name: commandName,
           enable: enabled,
@@ -74,6 +116,36 @@ export function Abilities() {
     }
   };
 
+  // Handle override extension toggle
+  const handleToggleOverride = (extensionKey: string) => {
+    const extension = OVERRIDE_EXTENSIONS[extensionKey];
+    const newState = !overrideStates[extensionKey];
+
+    setCookie(`agixt-${extension.name}`, newState.toString(), {
+      domain: process.env.NEXT_PUBLIC_COOKIE_DOMAIN,
+    });
+
+    setOverrideStates((prev) => ({
+      ...prev,
+      [extensionKey]: newState,
+    }));
+  };
+
+  // Check if an override extension matches the search text
+  const overrideMatchesSearch = (key: string, extension: (typeof OVERRIDE_EXTENSIONS)[keyof typeof OVERRIDE_EXTENSIONS]) => {
+    return (
+      !searchText ||
+      key.toLowerCase().includes(searchText.toLowerCase()) ||
+      extension.label.toLowerCase().includes(searchText.toLowerCase()) ||
+      extension.description.toLowerCase().includes(searchText.toLowerCase())
+    );
+  };
+
+  // Filter overrides based on search and showEnabledOnly
+  const filteredOverrides = Object.entries(OVERRIDE_EXTENSIONS)
+    .filter(([key, extension]) => overrideMatchesSearch(key, extension))
+    .filter(([key]) => !showEnabledOnly || overrideStates[key]);
+
   return (
     <div className='space-y-6'>
       <div className='flex items-center justify-between mb-4'>
@@ -84,34 +156,63 @@ export function Abilities() {
         </div>
       </div>
 
-      {extensionsWithCommands.length === 0 ? (
-        <Alert>
-          <AlertDescription>
-            No extensions are currently enabled. Enable extensions to see their abilities here.
-          </AlertDescription>
-        </Alert>
-      ) : (
-        <div className='grid gap-4'>
-          <Input placeholder='Search...' value={searchText} onChange={(e) => setSearchText(e.target.value)} />
-          {extensionsWithCommands
+      <div className='grid gap-4'>
+        <Input placeholder='Search...' value={searchText} onChange={(e) => setSearchText(e.target.value)} />
+
+        {/* AGiXT Core Features Card - Only show if not in company mode and matches filters */}
+        {searchParams.get('mode') !== 'company' && filteredOverrides.length > 0 && (
+          <Card>
+            <CardHeader>
+              <CardTitle>Agent Capabilities</CardTitle>
+              <CardDescription>Core features and capabilities</CardDescription>
+            </CardHeader>
+            <CardContent className='space-y-4'>
+              {filteredOverrides.map(([key, extension]) => (
+                <Card key={key} className='p-4 border border-border/50'>
+                  <div className='flex items-center mb-2'>
+                    <Switch checked={overrideStates[key] || false} onCheckedChange={() => handleToggleOverride(key)} />
+                    <div className='flex items-center ml-2'>
+                      <h4 className='text-lg font-medium'>{extension.label}</h4>
+                    </div>
+                  </div>
+                  <MarkdownBlock content={extension.description} />
+                </Card>
+              ))}
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Standard Extensions */}
+        {extensionsWithCommands.length === 0 && filteredOverrides.length === 0 ? (
+          <Alert>
+            <AlertDescription>
+              No extensions are currently enabled. Enable extensions to see their abilities here.
+            </AlertDescription>
+          </Alert>
+        ) : (
+          extensionsWithCommands
             .sort((a, b) => a.extension_name.localeCompare(b.extension_name))
-            .map((extension) => (
-              <Card key={extension.extension_name}>
-                <CardHeader>
-                  <CardTitle>{extension.extension_name}</CardTitle>
-                  <CardDescription>
-                    <MarkdownBlock content={extension.description || 'No description available'} />
-                  </CardDescription>
-                </CardHeader>
-                <CardContent className='space-y-4'>
-                  {extension.commands
-                    .filter((command) =>
-                      [command.command_name, command.extension_name, command.friendly_name, command.description].some(
-                        (value) => value?.toLowerCase().includes(searchText.toLowerCase()),
-                      ),
-                    )
-                    .filter((command) => !showEnabledOnly || command.enabled)
-                    .map((command) => (
+            .map((extension) => {
+              const filteredCommands = extension.commands
+                .filter((command) =>
+                  [command.command_name, command.extension_name, command.friendly_name, command.description].some((value) =>
+                    value?.toLowerCase().includes(searchText.toLowerCase()),
+                  ),
+                )
+                .filter((command) => !showEnabledOnly || command.enabled);
+
+              if (filteredCommands.length === 0) return null;
+
+              return (
+                <Card key={extension.extension_name}>
+                  <CardHeader>
+                    <CardTitle>{extension.extension_name}</CardTitle>
+                    <CardDescription>
+                      <MarkdownBlock content={extension.description || 'No description available'} />
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent className='space-y-4'>
+                    {filteredCommands.map((command) => (
                       <Card key={command.command_name} className='p-4 border border-border/50'>
                         <div className='flex items-center mb-2'>
                           <Switch
@@ -123,11 +224,13 @@ export function Abilities() {
                         <MarkdownBlock content={command.description?.split('\nArgs')[0] || 'No description available'} />
                       </Card>
                     ))}
-                </CardContent>
-              </Card>
-            ))}
-        </div>
-      )}
+                  </CardContent>
+                </Card>
+              );
+            })
+            .filter(Boolean)
+        )}
+      </div>
     </div>
   );
 }

--- a/components/agent/extension.tsx
+++ b/components/agent/extension.tsx
@@ -1,5 +1,4 @@
 import { Plus, Unlink, Wrench, Power, PowerOff } from 'lucide-react';
-import { useState, useEffect } from 'react';
 import MarkdownBlock from '@/components/conversation/Message/MarkdownBlock';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import {
@@ -14,14 +13,6 @@ import {
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { getCookie, setCookie } from 'cookies-next';
-
-const OVERRIDE_EXTENSIONS = {
-  'text-to-speech': { name: 'tts', label: 'Text to Speech' },
-  'web-search': { name: 'websearch', label: 'Web Search' },
-  'image-generation': { name: 'create-image', label: 'Image Generation' },
-  analysis: { name: 'analyze-user-input', label: 'File Analysis' },
-};
 
 export default function Extension({
   extension,
@@ -33,15 +24,6 @@ export default function Extension({
   error,
   setSelectedExtension = () => {},
 }) {
-  const [state, setState] = useState(false);
-
-  useEffect(() => {
-    setState(
-      Object.keys(OVERRIDE_EXTENSIONS).includes(extension.extension_name)
-        ? getCookie(`agixt-${OVERRIDE_EXTENSIONS[extension.extension_name].name}`) === 'true'
-        : false,
-    );
-  }, [extension.extension_name]);
   return (
     <div className='flex flex-col gap-2 p-3 transition-colors border rounded-lg bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60'>
       <div className='flex items-center gap-2'>
@@ -49,36 +31,11 @@ export default function Extension({
           <Wrench className='flex-shrink-0 w-5 h-5 text-muted-foreground' />
           <div>
             <h4 className='font-medium truncate'>{extension.friendly_name || extension.extension_name}</h4>
-            <p className='text-sm text-muted-foreground'>
-              {Object.keys(OVERRIDE_EXTENSIONS).includes(extension.extension_name)
-                ? state
-                  ? 'Enabled'
-                  : 'Disabled'
-                : connected
-                  ? 'Connected'
-                  : 'Not Connected'}
-            </p>
+            <p className='text-sm text-muted-foreground'>{connected ? 'Connected' : 'Not Connected'}</p>
           </div>
         </div>
 
-        {Object.keys(OVERRIDE_EXTENSIONS).includes(extension.extension_name) ? (
-          <Button
-            variant='outline'
-            size='sm'
-            className='gap-2'
-            onClick={() => {
-              setCookie(`agixt-${OVERRIDE_EXTENSIONS[extension.extension_name].name}`, (!state).toString(), {
-                domain: process.env.NEXT_PUBLIC_COOKIE_DOMAIN,
-                maxAge: 2147483647,
-                path: '/',
-              });
-              setState(!state);
-            }}
-          >
-            {state ? <PowerOff className='w-4 h-4' /> : <Power className='w-4 h-4' />}
-            {state ? 'Disable' : 'Enable'}
-          </Button>
-        ) : connected ? (
+        {connected ? (
           <Button variant='outline' size='sm' className='gap-2' onClick={() => onDisconnect(extension)}>
             <Unlink className='w-4 h-4' />
             Disconnect

--- a/components/agent/extensions.tsx
+++ b/components/agent/extensions.tsx
@@ -118,45 +118,6 @@ export function Extensions() {
         <p className='text-sm text-muted-foreground'>
           Manage your connected third-party extensions that grant your agent additional capabilities through abilities.
         </p>
-        {searchParams.get('mode') !== 'company' &&
-          [
-            {
-              extension_name: 'text-to-speech',
-              friendly_name: 'Text to Speech',
-              description: 'Convert text responses to spoken audio output.',
-              settings: [],
-            },
-            {
-              extension_name: 'web-search',
-              friendly_name: 'Web Search',
-              description: 'Search and reference current web content.',
-              settings: [],
-            },
-            {
-              extension_name: 'image-generation',
-              friendly_name: 'Image Generation',
-              description: 'Create AI-generated images from text descriptions.',
-              settings: [],
-            },
-            {
-              extension_name: 'analysis',
-              friendly_name: 'File Analysis',
-              description: 'Analyze uploaded files and documents for insights.',
-              settings: [],
-            },
-          ].map((ext) => (
-            <Extension
-              key={ext.extension_name}
-              extension={ext}
-              connected={false}
-              onConnect={() => {}}
-              onDisconnect={() => {}}
-              settings={{}}
-              setSettings={() => {}}
-              error={null}
-              setSelectedExtension={() => {}}
-            />
-          ))}
         {searchParams.get('mode') !== 'company' && <ConnectedServices />}
         {connectedExtensions.map((extension) => (
           <Extension


### PR DESCRIPTION
Fixes #85

Move and fix overrides

This pull request introduces significant changes to the `components/agent/abilities.tsx` file, focusing on the addition of override extensions and improvements to the user interface for managing these extensions. Additionally, some redundant code has been removed from the `components/agent/extension.tsx` and `components/agent/extensions.tsx` files.

### Key changes:

#### Override Extensions:
* Added definitions for override extensions such as 'text-to-speech', 'web-search', 'image-generation', and 'analysis' in `components/agent/abilities.tsx`.
* Implemented state management and initialization for override extensions using `useState` and `useEffect`.
* Added a handler for toggling the state of override extensions and saving the state in cookies.

#### User Interface Enhancements:
* Introduced a search input and filtering logic to display relevant override extensions and their states.
* Modified the rendering logic to include a card for AGiXT core features if not in company mode and matching filters.
* Improved the filtering and display logic for standard extensions, ensuring only relevant commands are shown.

#### Code Cleanup:
* Removed redundant state and effect logic related to override extensions from `components/agent/extension.tsx`.
* Deleted hardcoded override extensions from `components/agent/extensions.tsx` to streamline the code.