### PR TITLE
Use oauth connections from server

### DIFF
--- a/components/auth/OAuth.tsx
+++ b/components/auth/OAuth.tsx
@@ -53,7 +53,6 @@ const getIconByName = (name: string): ReactNode => {
     case 'microsoft':
       return <Microsoft />;
     case 'x':
-    case 'twitter':
       return <BsTwitterX />;
     case 'tesla':
       return <SiTesla />;

--- a/components/auth/OAuth.tsx
+++ b/components/auth/OAuth.tsx
@@ -13,26 +13,39 @@ import {
 } from 'react-icons/ri';
 import { BsTwitterX } from 'react-icons/bs';
 import { SiTesla } from 'react-icons/si';
-import { FaAws } from 'react-icons/fa';
+import { FaAws, FaDiscord } from 'react-icons/fa';
 import { TbBrandWalmart } from 'react-icons/tb';
 
+// Type definitions for provider data
+interface ApiProvider {
+  name: string;
+  scopes: string;
+  authorize: string;
+  client_id: string;
+}
+
+interface ProviderWithIcon {
+  client_id: string;
+  scope: string;
+  uri: string;
+  params: Record<string, any>;
+  icon: ReactNode;
+}
+
 // Empty providers object that will be populated from the API
-export const providers: Record<
-  string,
-  {
-    client_id: string;
-    scope: string;
-    uri: string;
-    params: Record<string, any>;
-    icon: ReactNode;
-  }
-> = {};
+export const providers: Record<string, ProviderWithIcon> = {};
+
+// Global loading state to track if providers have been loaded
+let providersLoaded = false;
+let loadingPromise: Promise<void> | null = null;
 
 // Icon mapping function based on provider name
 const getIconByName = (name: string): ReactNode => {
   const lowercaseName = name.toLowerCase();
 
   switch (lowercaseName) {
+    case 'discord':
+      return <FaDiscord />;
     case 'github':
       return <GitHub />;
     case 'google':
@@ -54,44 +67,14 @@ const getIconByName = (name: string): ReactNode => {
   }
 };
 
-// Fetch providers immediately on module import to populate the providers object
-(async () => {
-  try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_AGIXT_SERVER}/v1/oauth`);
-    if (response.ok) {
-      const data = await response.json();
-      const fetchedProviders = data.providers || [];
-
-      // Clear existing providers
-      Object.keys(providers).forEach((key) => delete providers[key]);
-
-      // Populate providers object for compatibility with other components
-      fetchedProviders.forEach((provider: any) => {
-        const name = provider.name.charAt(0).toUpperCase() + provider.name.slice(1);
-        providers[name] = {
-          client_id: provider.client_id,
-          scope: provider.scopes,
-          uri: provider.authorize,
-          params: name.toLowerCase() === 'google' ? { access_type: 'offline' } : {},
-          icon: getIconByName(provider.name),
-        };
-      });
-    }
-  } catch (err) {
-    console.error('Error loading OAuth providers:', err);
+// Function to load providers data
+export const loadProviders = async (): Promise<void> => {
+  if (providersLoaded) {
+    return;
   }
-})();
 
-export default function OAuth(): ReactNode {
-  const router = useRouter();
-  const { mutate } = useAgent();
-  const [loading, setLoading] = useState<boolean>(true);
-  const [error, setError] = useState<string | null>(null);
-  const [apiProviders, setApiProviders] = useState<any[]>([]);
-
-  // Fetch providers from API
-  useEffect(() => {
-    const fetchProviders = async () => {
+  if (!loadingPromise) {
+    loadingPromise = (async () => {
       try {
         const response = await fetch(`${process.env.NEXT_PUBLIC_AGIXT_SERVER}/v1/oauth`);
         if (!response.ok) {
@@ -100,12 +83,12 @@ export default function OAuth(): ReactNode {
 
         const data = await response.json();
         const fetchedProviders = data.providers || [];
-        setApiProviders(fetchedProviders);
 
-        // Update the exported providers object
+        // Clear existing providers
         Object.keys(providers).forEach((key) => delete providers[key]);
 
-        fetchedProviders.forEach((provider: any) => {
+        // Populate providers object
+        fetchedProviders.forEach((provider: ApiProvider) => {
           const name = provider.name.charAt(0).toUpperCase() + provider.name.slice(1);
           providers[name] = {
             client_id: provider.client_id,
@@ -115,15 +98,62 @@ export default function OAuth(): ReactNode {
             icon: getIconByName(provider.name),
           };
         });
-      } catch (err) {
-        setError('Error loading OAuth providers');
-        console.error(err);
-      } finally {
-        setLoading(false);
-      }
-    };
 
-    fetchProviders();
+        providersLoaded = true;
+      } catch (err) {
+        console.error('Error loading OAuth providers:', err);
+        // Reset loading promise so we can try again
+        loadingPromise = null;
+      }
+    })();
+  }
+
+  return loadingPromise;
+};
+
+// Load providers immediately (but don't block rendering)
+loadProviders();
+
+export default function OAuth(): ReactNode {
+  const router = useRouter();
+  const { mutate } = useAgent();
+  const [loading, setLoading] = useState(!providersLoaded);
+  const [error, setError] = useState<string | null>(null);
+  const [apiProviders, setApiProviders] = useState<ApiProvider[]>([]);
+
+  // Ensure providers are loaded before rendering
+  useEffect(() => {
+    if (!providersLoaded) {
+      setLoading(true);
+      loadProviders()
+        .then(() => {
+          setApiProviders(
+            Object.entries(providers).map(([key, value]) => ({
+              name: key.toLowerCase(),
+              scopes: value.scope,
+              authorize: value.uri,
+              client_id: value.client_id,
+            })),
+          );
+          setLoading(false);
+        })
+        .catch((err) => {
+          setError('Error loading OAuth providers');
+          setLoading(false);
+          console.error(err);
+        });
+    } else {
+      // Providers already loaded, just set them in state
+      setApiProviders(
+        Object.entries(providers).map(([key, value]) => ({
+          name: key.toLowerCase(),
+          scopes: value.scope,
+          authorize: value.uri,
+          client_id: value.client_id,
+        })),
+      );
+      setLoading(false);
+    }
   }, []);
 
   const onOAuth2 = useCallback(
@@ -144,33 +174,36 @@ export default function OAuth(): ReactNode {
 
   return (
     <>
-      {apiProviders.map((provider) => {
-        const name = provider.name.charAt(0).toUpperCase() + provider.name.slice(1);
-        return (
-          <OAuth2Login
-            key={provider.name}
-            authorizationUrl={provider.authorize}
-            responseType='code'
-            clientId={provider.client_id}
-            scope={provider.scopes}
-            redirectUri={`${process.env.NEXT_PUBLIC_APP_URI}/user/close/${provider.name.replaceAll('.', '-').replaceAll(' ', '-').replaceAll('_', '-').toLowerCase()}`}
-            onSuccess={onOAuth2}
-            onFailure={onOAuth2}
-            extraParams={name.toLowerCase() === 'google' ? { access_type: 'offline' } : {}}
-            isCrossOrigin
-            render={(renderProps) => (
-              <Button variant='outline' type='button' className='space-x-1 bg-transparent' onClick={renderProps.onClick}>
-                <span className='text-lg'>{getIconByName(provider.name)}</span>
-                {provider.name.toLowerCase() === 'x' ? (
-                  <span>Continue with &#120143; (Twitter) account</span>
-                ) : (
-                  <span>Continue with {name} account</span>
-                )}
-              </Button>
-            )}
-          />
-        );
-      })}
+      {apiProviders
+        .filter((provider) => provider.client_id) // Only show providers with client_id
+        .sort((a, b) => a.name.localeCompare(b.name)) // Sort alphabetically by name
+        .map((provider) => {
+          const name = provider.name.charAt(0).toUpperCase() + provider.name.slice(1);
+          return (
+            <OAuth2Login
+              key={provider.name}
+              authorizationUrl={provider.authorize}
+              responseType='code'
+              clientId={provider.client_id}
+              scope={provider.scopes}
+              redirectUri={`${process.env.NEXT_PUBLIC_APP_URI}/user/close/${provider.name.replaceAll('.', '-').replaceAll(' ', '-').replaceAll('_', '-').toLowerCase()}`}
+              onSuccess={onOAuth2}
+              onFailure={onOAuth2}
+              extraParams={provider.name.toLowerCase() === 'google' ? { access_type: 'offline' } : {}}
+              isCrossOrigin
+              render={(renderProps) => (
+                <Button variant='outline' type='button' className='space-x-1 bg-transparent' onClick={renderProps.onClick}>
+                  <span className='text-lg'>{getIconByName(provider.name)}</span>
+                  {provider.name.toLowerCase() === 'x' ? (
+                    <span>Continue with &#120143; (Twitter) account</span>
+                  ) : (
+                    <span>Continue with {name} account</span>
+                  )}
+                </Button>
+              )}
+            />
+          );
+        })}
     </>
   );
 }

--- a/components/auth/OAuth.tsx
+++ b/components/auth/OAuth.tsx
@@ -3,7 +3,7 @@
 import { useAgent } from '@/components/interactive/useAgent';
 import { Button } from '@/components/ui/button';
 import { useRouter } from 'next/navigation';
-import { ReactNode, useCallback } from 'react';
+import { ReactNode, useCallback, useEffect, useState } from 'react';
 import OAuth2Login from 'react-simple-oauth2-login';
 import {
   RiGithubFill as GitHub,
@@ -16,101 +16,159 @@ import { SiTesla } from 'react-icons/si';
 import { FaAws } from 'react-icons/fa';
 import { TbBrandWalmart } from 'react-icons/tb';
 
-export const providers = {
-  Amazon: {
-    client_id: process.env.NEXT_PUBLIC_AMAZON_CLIENT_ID,
-    scope: 'profile',
-    uri: 'https://www.amazon.com/ap/oa',
-    params: {},
-    icon: <FaAws />,
-  },
-  Tesla: {
-    client_id: process.env.NEXT_PUBLIC_TESLA_CLIENT_ID,
-    scope: 'openid offline_access user_data vehicle_device_data vehicle_cmds vehicle_charging_cmds vehicle_location',
-    uri: 'https://auth.tesla.com/oauth2/v3/authorize',
-    params: {},
-    icon: <SiTesla />,
-  },
-  GitHub: {
-    client_id: process.env.NEXT_PUBLIC_GITHUB_CLIENT_ID,
-    scope: process.env.NEXT_PUBLIC_GITHUB_SCOPES || 'user:email',
-    uri: 'https://github.com/login/oauth/authorize',
-    params: {},
-    icon: <GitHub />,
-  },
-  Google: {
-    client_id: process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID,
-    scope: process.env.NEXT_PUBLIC_GOOGLE_SCOPES || 'profile email https://www.googleapis.com/auth/gmail.send',
-    uri: 'https://accounts.google.com/o/oauth2/v2/auth',
-    params: {
-      access_type: 'offline',
-    },
-    icon: <Google />,
-  },
-  Microsoft: {
-    client_id: process.env.NEXT_PUBLIC_MICROSOFT_CLIENT_ID,
-    scope:
-      process.env.NEXT_PUBLIC_MICROSOFT_SCOPES ||
-      'https://graph.microsoft.com/User.Read https://graph.microsoft.com/Mail.Send https://graph.microsoft.com/Calendars.ReadWrite.Shared',
-    uri: 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize',
-    params: {},
-    icon: <Microsoft />,
-  },
-  X: {
-    client_id: process.env.NEXT_PUBLIC_X_CLIENT_ID,
-    scope:
-      'tweet.read tweet.write users.read offline.access like.read like.write follows.read follows.write dm.read dm.write',
-    uri: 'https://twitter.com/i/oauth2/authorize',
-    params: {},
-    icon: <BsTwitterX />,
-  },
-  Walmart: {
-    client_id: process.env.NEXT_PUBLIC_WALMART_CLIENT_ID,
-    scope: 'orders items inventory pricing reports returns',
-    uri: 'https://developer.walmart.com/api/oauth/authorize',
-    params: {},
-    icon: <TbBrandWalmart />,
-  },
+// Empty providers object that will be populated from the API
+export const providers: Record<
+  string,
+  {
+    client_id: string;
+    scope: string;
+    uri: string;
+    params: Record<string, any>;
+    icon: ReactNode;
+  }
+> = {};
+
+// Icon mapping function based on provider name
+const getIconByName = (name: string): ReactNode => {
+  const lowercaseName = name.toLowerCase();
+
+  switch (lowercaseName) {
+    case 'github':
+      return <GitHub />;
+    case 'google':
+      return <Google />;
+    case 'microsoft':
+      return <Microsoft />;
+    case 'x':
+    case 'twitter':
+      return <BsTwitterX />;
+    case 'tesla':
+      return <SiTesla />;
+    case 'amazon':
+      return <FaAws />;
+    case 'walmart':
+      return <TbBrandWalmart />;
+    default:
+      // Default icon for providers without specific icons
+      return <ShoppingCartOutlined />;
+  }
 };
+
+// Fetch providers immediately on module import to populate the providers object
+(async () => {
+  try {
+    const response = await fetch(`${process.env.NEXT_PUBLIC_AGIXT_SERVER}/v1/oauth`);
+    if (response.ok) {
+      const data = await response.json();
+      const fetchedProviders = data.providers || [];
+
+      // Clear existing providers
+      Object.keys(providers).forEach((key) => delete providers[key]);
+
+      // Populate providers object for compatibility with other components
+      fetchedProviders.forEach((provider: any) => {
+        const name = provider.name.charAt(0).toUpperCase() + provider.name.slice(1);
+        providers[name] = {
+          client_id: provider.client_id,
+          scope: provider.scopes,
+          uri: provider.authorize,
+          params: name.toLowerCase() === 'google' ? { access_type: 'offline' } : {},
+          icon: getIconByName(provider.name),
+        };
+      });
+    }
+  } catch (err) {
+    console.error('Error loading OAuth providers:', err);
+  }
+})();
 
 export default function OAuth(): ReactNode {
   const router = useRouter();
   const { mutate } = useAgent();
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+  const [apiProviders, setApiProviders] = useState<any[]>([]);
+
+  // Fetch providers from API
+  useEffect(() => {
+    const fetchProviders = async () => {
+      try {
+        const response = await fetch(`${process.env.NEXT_PUBLIC_AGIXT_SERVER}/v1/oauth`);
+        if (!response.ok) {
+          throw new Error('Failed to fetch OAuth providers');
+        }
+
+        const data = await response.json();
+        const fetchedProviders = data.providers || [];
+        setApiProviders(fetchedProviders);
+
+        // Update the exported providers object
+        Object.keys(providers).forEach((key) => delete providers[key]);
+
+        fetchedProviders.forEach((provider: any) => {
+          const name = provider.name.charAt(0).toUpperCase() + provider.name.slice(1);
+          providers[name] = {
+            client_id: provider.client_id,
+            scope: provider.scopes,
+            uri: provider.authorize,
+            params: name.toLowerCase() === 'google' ? { access_type: 'offline' } : {},
+            icon: getIconByName(provider.name),
+          };
+        });
+      } catch (err) {
+        setError('Error loading OAuth providers');
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchProviders();
+  }, []);
+
   const onOAuth2 = useCallback(
     (response: any) => {
       mutate();
       document.location.href = `${process.env.NEXT_PUBLIC_APP_URI}/chat`;
     },
-    [router],
+    [mutate],
   );
+
+  if (loading) {
+    return <div>Loading authentication options...</div>;
+  }
+
+  if (error) {
+    return <div>Error: {error}</div>;
+  }
+
   return (
     <>
-      {Object.entries(providers).map(([key, provider]) => {
+      {apiProviders.map((provider) => {
+        const name = provider.name.charAt(0).toUpperCase() + provider.name.slice(1);
         return (
-          provider.client_id && (
-            <OAuth2Login
-              key={key}
-              authorizationUrl={provider.uri}
-              responseType='code'
-              clientId={provider.client_id}
-              scope={provider.scope}
-              redirectUri={`${process.env.NEXT_PUBLIC_APP_URI}/user/close/${key.replaceAll('.', '-').replaceAll(' ', '-').replaceAll('_', '-').toLowerCase()}`}
-              onSuccess={onOAuth2}
-              onFailure={onOAuth2}
-              extraParams={provider.params}
-              isCrossOrigin
-              render={(renderProps) => (
-                <Button variant='outline' type='button' className='space-x-1 bg-transparent' onClick={renderProps.onClick}>
-                  <span className='text-lg'>{provider.icon}</span>
-                  {key === 'X' ? (
-                    <span>Continue with &#120143; (Twitter) account</span>
-                  ) : (
-                    <span>Continue with {key} account</span>
-                  )}
-                </Button>
-              )}
-            />
-          )
+          <OAuth2Login
+            key={provider.name}
+            authorizationUrl={provider.authorize}
+            responseType='code'
+            clientId={provider.client_id}
+            scope={provider.scopes}
+            redirectUri={`${process.env.NEXT_PUBLIC_APP_URI}/user/close/${provider.name.replaceAll('.', '-').replaceAll(' ', '-').replaceAll('_', '-').toLowerCase()}`}
+            onSuccess={onOAuth2}
+            onFailure={onOAuth2}
+            extraParams={name.toLowerCase() === 'google' ? { access_type: 'offline' } : {}}
+            isCrossOrigin
+            render={(renderProps) => (
+              <Button variant='outline' type='button' className='space-x-1 bg-transparent' onClick={renderProps.onClick}>
+                <span className='text-lg'>{getIconByName(provider.name)}</span>
+                {provider.name.toLowerCase() === 'x' ? (
+                  <span>Continue with &#120143; (Twitter) account</span>
+                ) : (
+                  <span>Continue with {name} account</span>
+                )}
+              </Button>
+            )}
+          />
         );
       })}
     </>

--- a/docs/README.md
+++ b/docs/README.md
@@ -59,25 +59,11 @@ The following environment variables can be set:
 | `APP_NAME` | `AGiXT` | The name of the AGiXT application. |
 | `APP_DESCRIPTION` | `An AGiXT application.` | Description of the AGiXT application. |
 | `APP_URI` | `http://localhost:3437` | The URI of the AGiXT application. |
-| `THEME_DEFAULT_MODE` | `dark` | The default theme mode for AGiXT. |
 | `TZ` | `America/New_York` | The timezone used by the application. |
 | `DEFAULT_THEME_MODE` | `dark` | Alternative setting for the default theme mode. |
-| `ADSENSE_ACCOUNT` | `` | Google AdSense account ID if applicable. |
-| `ENV` | `development` | Environment mode (development/production). |
-| `LOG_VERBOSITY_CLIENT` | `3` | Client-side logging verbosity level. |
 | `PRIVATE_ROUTES` | `/chat,/team,/settings/` | Routes that require authentication. |
 | `AGIXT_SERVER` | `http://agixt:7437` | The server address for AGiXT. |
 | `ALLOW_EMAIL_SIGN_IN` | `true` | Whether to allow email sign-in. |
-| `GITHUB_CLIENT_ID` | `` | GitHub OAuth client ID. |
-| `GITHUB_SCOPES` | `repo user:email read:user workflow` | GitHub OAuth scopes. |
-| `GOOGLE_CLIENT_ID` | `` | Google OAuth client ID. |
-| `GOOGLE_SCOPES` | `https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/calendar.events.owned https://www.googleapis.com/auth/contacts.readonly https://www.googleapis.com/auth/gmail.modify` | Google OAuth scopes. |
-| `MICROSOFT_CLIENT_ID` | `` | Microsoft OAuth client ID. |
-| `MICROSOFT_SCOPES` | `offline_access User.Read Mail.Send Calendars.ReadWrite Calendars.ReadWrite.Shared` | Microsoft OAuth scopes. |
-| `TESLA_CLIENT_ID` | `` | Tesla OAuth client ID. |
-| `TESLA_SCOPES` | `openid offline_access user_data vehicle_device_data vehicle_cmds vehicle_charging_cmds vehicle_location` | Tesla OAuth scopes. |
-| `COOKIE_DOMAIN` | `localhost` | Domain for cookies. |
-| `AGIXT_API_KEY` | `` | API key for AGiXT. |
 | `AGIXT_CONVERSATION` | `-` | The name of the conversation in AGiXT. |
 | `INTERACTIVE_UI` | `chat` | The interactive UI mode for AGiXT. |
 | `AGIXT_FOOTER_MESSAGE` | `Powered by AGiXT` | The footer message displayed in AGiXT. |
@@ -88,12 +74,6 @@ The following environment variables can be set:
 | `AGIXT_ALLOW_MESSAGE_DELETION` | `true` | Whether to allow message deletion. |
 | `AGIXT_SHOW_OVERRIDE_SWITCHES` | `tts,websearch` | Which override switches to show. |
 | `AGIXT_AGENT` | `AGiXT` | The default agent used in AGiXT. |
-| `AGIXT_PROMPT_NAME` | `Think About It` | Default prompt name. |
-| `AGIXT_PROMPT_CATEGORY` | `Default` | Default prompt category. |
-| `AGIXT_COMMAND` | `` | Default command to execute. |
-| `AGIXT_COMMAND_MESSAGE_ARG` | `message` | Argument name for command messages. |
-| `AGIXT_CHAIN` | `` | Default chain to execute. |
-| `AGIXT_CHAIN_ARGS` | `{}` | Arguments for the default chain. |
 
 Configuration can also be set via search params / query params, if enabled via the `AGIXT_ENABLE_SEARCHPARAM_CONFIG` setting.
 

--- a/export-codebase.ipynb
+++ b/export-codebase.ipynb
@@ -2,14 +2,14 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Tokens: 121342\n"
+      "Tokens: 115760\n"
      ]
     }
    ],

--- a/next.config.js
+++ b/next.config.js
@@ -31,8 +31,6 @@ let nextConfig = {
     NEXT_PUBLIC_ADSENSE_ACCOUNT: process.env.ADSENSE_ACCOUNT || '',
     NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: process.env.STRIPE_PUBLISHABLE_KEY || '',
     NEXT_PUBLIC_STRIPE_PRICING_TABLE_ID: process.env.STRIPE_PRICING_TABLE_ID || '',
-    NEXT_PUBLIC_AGIXT_API_KEY: process.env.AGIXT_API_KEY || '',
-    NEXT_PUBLIC_AGIXT_CONVERSATION_NAME: process.env.AGIXT_CONVERSATION || '-',
     // UI Options
     NEXT_PUBLIC_AGIXT_FOOTER_MESSAGE: process.env.AGIXT_FOOTER_MESSAGE || 'Powered by AGiXT',
     NEXT_PUBLIC_AGIXT_RLHF: process.env.AGIXT_RLHF || 'true',
@@ -42,7 +40,7 @@ let nextConfig = {
     NEXT_PUBLIC_AGIXT_ALLOW_MESSAGE_DELETION: process.env.AGIXT_ALLOW_MESSAGE_DELETION || 'true',
     NEXT_PUBLIC_AGIXT_SHOW_OVERRIDE_SWITCHES: process.env.AGIXT_SHOW_OVERRIDE_SWITCHES || 'tts,websearch',
     // State Options
-    NEXT_PUBLIC_AGIXT_AGENT: process.env.AGIXT_AGENT || 'AGiXT',
+    NEXT_PUBLIC_AGIXT_AGENT: process.env.AGIXT_AGENT || 'XT',
   },
   images: AGIXT_SERVER && {
     remotePatterns: [

--- a/next.config.js
+++ b/next.config.js
@@ -29,23 +29,6 @@ let nextConfig = {
     NEXT_PUBLIC_THEME_DEFAULT_MODE: process.env.DEFAULT_THEME_MODE || 'dark',
     NEXT_PUBLIC_TZ: process.env.TZ || 'America/New_York', // Server timezone
     NEXT_PUBLIC_ADSENSE_ACCOUNT: process.env.ADSENSE_ACCOUNT || '',
-    NEXT_PUBLIC_AMAZON_CLIENT_ID: process.env.AMAZON_CLIENT_ID || '',
-    NEXT_PUBLIC_AMAZON_SCOPES: process.env.AMAZON_SCOPES || '',
-    NEXT_PUBLIC_GITHUB_CLIENT_ID: process.env.GITHUB_CLIENT_ID || '',
-    NEXT_PUBLIC_GITHUB_SCOPES: process.env.GITHUB_SCOPES || 'repo user:email read:user workflow',
-    NEXT_PUBLIC_GITLAB_CLIENT_ID: process.env.GITLAB_CLIENT_ID || '',
-    NEXT_PUBLIC_GOOGLE_CLIENT_ID: process.env.GOOGLE_CLIENT_ID || '',
-    NEXT_PUBLIC_GOOGLE_SCOPES:
-      process.env.GOOGLE_SCOPES ||
-      'https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/calendar.events.owned https://www.googleapis.com/auth/contacts.readonly https://www.googleapis.com/auth/gmail.modify',
-    NEXT_PUBLIC_MICROSOFT_CLIENT_ID: process.env.MICROSOFT_CLIENT_ID || '',
-    NEXT_PUBLIC_MICROSOFT_SCOPES:
-      process.env.MICROSOFT_SCOPES || 'offline_access User.Read Mail.Send Calendars.ReadWrite Calendars.ReadWrite.Shared',
-    NEXT_PUBLIC_TESLA_CLIENT_ID: process.env.TESLA_CLIENT_ID || '',
-    NEXT_PUBLIC_TESLA_SCOPES:
-      process.env.TESLA_SCOPES ||
-      'openid offline_access user_data vehicle_device_data vehicle_cmds vehicle_charging_cmds vehicle_location',
-    NEXT_PUBLIC_X_CLIENT_ID: process.env.X_CLIENT_ID || '',
     NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: process.env.STRIPE_PUBLISHABLE_KEY || '',
     NEXT_PUBLIC_STRIPE_PRICING_TABLE_ID: process.env.STRIPE_PRICING_TABLE_ID || '',
     NEXT_PUBLIC_AGIXT_API_KEY: process.env.AGIXT_API_KEY || '',


### PR DESCRIPTION
This pull request includes significant changes to the `components/auth/OAuth.tsx` file to dynamically fetch and populate OAuth providers from an API instead of hardcoding them. The changes also include improvements to error handling and loading states.

Dynamic OAuth providers:

* Replaced the hardcoded `providers` object with an empty object that will be populated from the API.
* Added a function `getIconByName` to map provider names to their respective icons.
* Implemented an immediately-invoked function expression (IIFE) to fetch providers from the API and populate the `providers` object.
* Updated the `OAuth` component to use `useEffect` for fetching providers from the API and managing loading and error states. [[1]](diffhunk://#diff-64ef5f65496996910546a58aa0e59164608d88546cfca22549be0a942e42c411L6-R6) [[2]](diffhunk://#diff-64ef5f65496996910546a58aa0e59164608d88546cfca22549be0a942e42c411L19-L113)
* Modified the rendering logic to use the dynamically fetched `apiProviders` instead of the hardcoded `providers`.