### PR TITLE
Issue-93 Add Change Role to .. on Team page under User Actions above Delete User

### DIFF
--- a/app/team/page.tsx
+++ b/app/team/page.tsx
@@ -211,6 +211,99 @@ export const TeamUsers = () => {
               <DropdownMenuSeparator />
               <DropdownMenuItem
                 onClick={(e) => {
+                  const data = {
+                      role_id: 3,
+                      company_id: activeCompany?.id,
+                      user_id: row.original.id
+                    }
+                  axios.put(
+                    `${process.env.NEXT_PUBLIC_AGIXT_SERVER}/v1/user/role`,
+                    data,
+                    {
+                      headers: {
+                        Authorization: getCookie('jwt'),
+                        'Content-Type': 'application/json',
+                        },
+                      },
+                    ).then((response)=>{
+                    mutate();
+                    setResponseMessage('User Role updated successfully!');
+                    })
+                  }
+                }
+                className='p-0'
+              >
+                <Button 
+                  variant='ghost' 
+                  className='justify-start w-full text-white-600 hover:text-blue-600'
+                >
+                  Change Role To User
+                </Button>
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={(e) => {
+                  const data = {
+                      role_id: 2,
+                      company_id: activeCompany?.id,
+                      user_id: row.original.id
+                    }
+                  axios.put(
+                    `${process.env.NEXT_PUBLIC_AGIXT_SERVER}/v1/user/role`,
+                    data,
+                    {
+                      headers: {
+                        Authorization: getCookie('jwt'),
+                        'Content-Type': 'application/json',
+                        },
+                      },
+                    ).then((response)=>{
+                    mutate();
+                    setResponseMessage('User Role updated successfully!');
+                    })
+                  }
+                }
+                className='p-0'
+              >
+                <Button 
+                  variant='ghost' 
+                  className='justify-start w-full text-white-600 hover:text-blue-600'
+                >
+                  Change Role To Company Admin
+                </Button>
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={(e) => {
+                  const data = {
+                      role_id: 1,
+                      company_id: activeCompany?.id,
+                      user_id: row.original.id
+                    }
+                  axios.put(
+                    `${process.env.NEXT_PUBLIC_AGIXT_SERVER}/v1/user/role`,
+                    data,
+                    {
+                      headers: {
+                        Authorization: getCookie('jwt'),
+                        'Content-Type': 'application/json',
+                        },
+                      },
+                    ).then((response)=>{
+                    mutate();
+                    setResponseMessage('User Role updated successfully!');
+                    })
+                  }
+                }
+                className='p-0'
+              >
+                <Button 
+                  variant='ghost' 
+                  className='justify-start w-full text-white-600 hover:text-blue-600'
+                >
+                  Change Role To Tenant Admin
+                </Button>
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={(e) => {
                   axios.delete(
                     `${process.env.NEXT_PUBLIC_AGIXT_SERVER}/v1/companies/${activeCompany?.id}/users/${row.original.id}`,
                     {

--- a/app/team/page.tsx
+++ b/app/team/page.tsx
@@ -235,7 +235,7 @@ export const TeamUsers = () => {
               >
                 <Button 
                   variant='ghost' 
-                  className='justify-start w-full text-white-600 hover:text-blue-600'
+                  className='justify-start w-full text-white-600 hover:text-blue-600 text-left whitespace-normal break-words px-2'
                 >
                   Change Role To User
                 </Button>
@@ -266,7 +266,7 @@ export const TeamUsers = () => {
               >
                 <Button 
                   variant='ghost' 
-                  className='justify-start w-full text-white-600 hover:text-blue-600'
+                  className='justify-start w-full text-white-600 hover:text-blue-600 text-left whitespace-normal break-words px-2'
                 >
                   Change Role To Company Admin
                 </Button>
@@ -297,7 +297,7 @@ export const TeamUsers = () => {
               >
                 <Button 
                   variant='ghost' 
-                  className='justify-start w-full text-white-600 hover:text-blue-600'
+                  className='justify-start w-full text-white-600 hover:text-blue-600 text-left whitespace-normal break-words px-2'
                 >
                   Change Role To Tenant Admin
                 </Button>

--- a/app/team/page.tsx
+++ b/app/team/page.tsx
@@ -240,6 +240,7 @@ export const TeamUsers = () => {
                   Change Role To User
                 </Button>
               </DropdownMenuItem>
+              <DropdownMenuSeparator />
               <DropdownMenuItem
                 onClick={(e) => {
                   const data = {
@@ -271,6 +272,7 @@ export const TeamUsers = () => {
                   Change Role To Company Admin
                 </Button>
               </DropdownMenuItem>
+              <DropdownMenuSeparator />
               <DropdownMenuItem
                 onClick={(e) => {
                   const data = {
@@ -302,6 +304,7 @@ export const TeamUsers = () => {
                   Change Role To Tenant Admin
                 </Button>
               </DropdownMenuItem>
+              <DropdownMenuSeparator />
               <DropdownMenuItem
                 onClick={(e) => {
                   axios.delete(


### PR DESCRIPTION
## Pull Request: Add Role Change Options to Team Page

### Summary
Adds role change functionality to the Team page dropdown menu, allowing administrators to modify user roles directly from the user management interface.

### Changes
- Added three dropdown menu items for changing user roles:
  1. Change Role to User (role_id: 3)
  2. Change Role to Company Admin (role_id: 2)
  3. Change Role to Tenant Admin (role_id: 1)
- Implemented axios PUT request to update user roles
- Included mutate() to refresh data after role change

### Details
- Endpoint: `${process.env.NEXT_PUBLIC_AGIXT_SERVER}/v1/user/role`
- Sends user_id, role_id, and company_id in request payload
- Uses JWT authorization
- Provides immediate user feedback

### Commit Message
```
feat(team-management): Add role change options for users

- Implement dropdown menu buttons for changing user roles
- Support changing to User, Company Admin, and Tenant Admin roles
- Add API request and data mutation for role updates
```

### Related Issue
Closes #93

### Testing
- Verify each role change option works correctly
- Check that user list refreshes after role change