### PR TITLE
Fix #154: Remove the up arrow from the chat bar

### DIFF
--- a/components/conversation/input/chat-input.tsx
+++ b/components/conversation/input/chat-input.tsx
@@ -553,7 +553,6 @@ export function ChatBar({
                 <BiCollapseVertical className='w-4 h-4' />
               </Button>
             </TooltipBasic>
-            {showOverrideSwitchesCSV && <OverrideSwitches showOverrideSwitches={showOverrideSwitchesCSV} />}
             {enableVoiceInput && <VoiceRecorder onSend={onSend} disabled={disabled} />}
             {showResetConversation && <ResetConversation state={state} setCookie={setCookie} />}
             {!alternativeInputActive && (


### PR DESCRIPTION
Resolves #154

The following modifications were applied:


 Here are the changes needed to remove the up arrow from the chat bar:
 

 ```xml
 ```xml
<modification>
 <file>components/conversation/input/chat-input.tsx</file>
 <operation>delete</operation>
 <target>
 {showOverrideSwitchesCSV && <OverrideSwitches showOverrideSwitches={showOverrideSwitchesCSV} />}
 </target>
 </modification>
```
 ```
 