### PR TITLE
Fix billing user status bug: users with credits now remain active

### DIFF
--- a/middleware.tsx
+++ b/middleware.tsx
@@ -193,19 +193,22 @@ export const useAuth: MiddlewareHook = async (req) => {
           `${response.status === 401 ? 'Unauthorized' : 'Forbidden'} access, status ${response.status}, detail ${responseJSON.detail}. Clearing JWT and redirecting to auth.`,
         );
       } else if (response.status === 402) {
-        // Payment Required
-        if (!requestedURI.startsWith(`${authWeb}/subscribe`)) {
+        // Payment Required - Only redirect if user doesn't have active credits
+        // Check if user has credits (input_tokens or output_tokens > 0) - if so, they should be considered active
+        const hasActiveCredits =
+          responseJSON.detail?.input_tokens > 0 ||
+          responseJSON.detail?.output_tokens > 0 ||
+          responseJSON.detail?.is_active === true;
+
+        if (!hasActiveCredits && !requestedURI.startsWith(`${authWeb}/subscribe`)) {
+          // Safely access customer_session - it may not always be present
+          const clientSecret = responseJSON.detail?.customer_session?.client_secret;
           toReturn.response = NextResponse.redirect(
-            new URL(
-              `${authWeb}/subscribe${
-                responseJSON.detail.customer_session.client_secret
-                  ? '?customer_session=' + responseJSON.detail.customer_session.client_secret
-                  : ''
-              }`,
-            ),
+            new URL(`${authWeb}/subscribe${clientSecret ? '?customer_session=' + clientSecret : ''}`),
           );
           toReturn.activated = true;
         }
+        // If user has active credits, don't redirect - let them proceed (treat as 200)
       } else if (response.status === 502) {
         const cookieArray = [generateCookieString('href', requestedURI, (86400).toString())];
         toReturn.activated = true;


### PR DESCRIPTION
## Summary

This PR fixes a critical bug where users who have been issued credits were incorrectly showing as inactive and unable to log in.

## Problem

Users who received credits were being incorrectly redirected to the subscription page and couldn't access the application. The root cause was in the middleware's handling of HTTP 402 (Payment Required) responses:

1. **Missing credit check**: The middleware redirected ALL 402 responses to the subscribe page without checking if the user actually had active credits (input_tokens, output_tokens, or is_active flag).

2. **Unsafe property access**: The code assumed `responseJSON.detail.customer_session` always existed, which could cause runtime errors when the response structure differed after credit issuance.

## Solution

Modified the 402 response handling in `middleware.tsx` to:

1. **Check for active credits**: Before redirecting to the subscribe page, the middleware now checks if the user has:
   - `input_tokens > 0`
   - `output_tokens > 0`  
   - `is_active === true`

2. **Use safe property access**: Added optional chaining (`?.`) for accessing `customer_session.client_secret` to prevent runtime errors.

3. **Allow active users through**: Users with active credits are no longer redirected to the subscribe page - they proceed as if they received a 200 response.

## Changes

- `middleware.tsx`: Updated 402 handling logic with credit checks and safe property access

## Testing

- [x] Lint check passes
- [x] Build completes successfully
- [x] No new TypeScript errors introduced

## How to Test

1. Simulate a user account with issued credits
2. Attempt to log in
3. Verify user can access the application without being redirected to subscribe page

## Impact

- **Fixes**: Users with credits can now log in and access the application
- **Safe**: No breaking changes for users without credits - they will still be properly redirected to subscribe
- **Minimal**: Single file change with backwards-compatible logic